### PR TITLE
Refresh local lab tools

### DIFF
--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -90,9 +90,74 @@
   background: color-mix(in srgb, #37a169 35%, transparent);
 }
 
+.roomos-tool__diff-results {
+  gap: 0;
+}
+
+.roomos-tool__diff-heading,
+.roomos-tool__diff-row {
+  display: grid;
+  grid-template-columns: 3rem 3rem minmax(0, 1fr);
+}
+
+.roomos-tool__diff-heading {
+  border-bottom: 1px solid var(--md-default-fg-color--lighter);
+  color: var(--md-default-fg-color--light);
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.35rem 0;
+  text-transform: uppercase;
+}
+
+.roomos-tool__diff-view {
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-top: 0;
+  max-height: 38rem;
+  overflow: auto;
+}
+
+.roomos-tool__diff-row {
+  font-family: var(--md-code-font-family);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  min-width: 32rem;
+}
+
+.roomos-tool__diff-line-number {
+  border-right: 1px solid color-mix(in srgb, var(--md-default-fg-color) 20%, transparent);
+  color: var(--md-default-fg-color--lighter);
+  padding: 0.1rem 0.35rem;
+  text-align: right;
+  user-select: none;
+}
+
+.roomos-tool__diff-content {
+  overflow-wrap: anywhere;
+  padding: 0.1rem 0.75rem;
+  white-space: pre-wrap;
+}
+
+.roomos-tool__diff-row--delete {
+  background: color-mix(in srgb, #e55353 20%, transparent);
+}
+
+.roomos-tool__diff-row--insert {
+  background: color-mix(in srgb, #37a169 24%, transparent);
+}
+
+.roomos-tool__diff-row--skip {
+  background: var(--md-code-bg-color);
+  color: var(--md-default-fg-color--light);
+  font-style: italic;
+}
+
+.roomos-tool__diff-row--skip .roomos-tool__diff-content {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
 @media screen and (min-width: 76.25em) {
-  .roomos-tool__grid--two-up,
-  .roomos-tool__results {
+  .roomos-tool__grid--two-up {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -19,6 +19,10 @@
   gap: 0.35rem;
 }
 
+.roomos-tool__field[hidden] {
+  display: none;
+}
+
 .roomos-tool__field label,
 .roomos-tool__field h3 {
   font-weight: 700;

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -1,0 +1,94 @@
+.roomos-tool {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.roomos-tool__grid,
+.roomos-tool__results {
+  display: grid;
+  gap: 1rem;
+}
+
+.roomos-tool__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.roomos-tool__field label,
+.roomos-tool__field h3 {
+  font-weight: 700;
+  margin: 0;
+}
+
+.roomos-tool textarea,
+.roomos-tool__output {
+  box-sizing: border-box;
+  min-height: 10rem;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.2rem;
+  background: var(--md-code-bg-color);
+  color: var(--md-code-fg-color);
+  font-family: var(--md-code-font-family);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.roomos-tool__output {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.roomos-tool__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.roomos-tool__actions .md-button:not(.md-button--primary) {
+  border-color: var(--md-typeset-a-color);
+  color: var(--md-typeset-a-color);
+}
+
+.roomos-tool__actions .md-button:not(.md-button--primary):disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.roomos-tool__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.roomos-tool__status {
+  min-height: 1.5rem;
+  margin: 0;
+}
+
+.roomos-tool__status[data-state="success"] {
+  color: var(--md-typeset-a-color);
+}
+
+.roomos-tool__status[data-state="error"] {
+  color: #d33;
+}
+
+.roomos-tool__difference {
+  background: color-mix(in srgb, #e55353 30%, transparent);
+}
+
+.roomos-tool__addition {
+  background: color-mix(in srgb, #37a169 35%, transparent);
+}
+
+@media screen and (min-width: 76.25em) {
+  .roomos-tool__grid--two-up,
+  .roomos-tool__results {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -10,6 +10,10 @@
   gap: 0.75rem;
 }
 
+.roomos-tool__results[hidden] {
+  display: none;
+}
+
 .roomos-tool__field {
   display: grid;
   gap: 0.35rem;

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -1,13 +1,13 @@
 .roomos-tool {
   display: grid;
-  gap: 0.9rem;
-  margin-top: 1rem;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
 }
 
 .roomos-tool__grid,
 .roomos-tool__results {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .roomos-tool__field {
@@ -24,7 +24,7 @@
 .roomos-tool textarea,
 .roomos-tool__output {
   box-sizing: border-box;
-  min-height: 10rem;
+  min-height: 8rem;
   width: 100%;
   padding: 0.75rem;
   border: 1px solid var(--md-default-fg-color--lighter);
@@ -46,7 +46,7 @@
 .roomos-tool__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .roomos-tool__actions .md-button:not(.md-button--primary) {
@@ -66,7 +66,7 @@
 }
 
 .roomos-tool__status {
-  min-height: 1.5rem;
+  min-height: 1.25rem;
   margin: 0;
 }
 

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -91,6 +91,37 @@
   max-width: 100%;
 }
 
+.roomos-tool__subtabs {
+  border-bottom: 1px solid var(--md-default-fg-color--lighter);
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+
+.roomos-tool__subtabs button {
+  background: transparent;
+  border: 0;
+  border-bottom: 0.15rem solid transparent;
+  color: var(--md-default-fg-color--light);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.65rem 0.75rem 0.5rem;
+  white-space: nowrap;
+}
+
+.roomos-tool__subtabs button[aria-selected="true"] {
+  border-bottom-color: var(--md-typeset-a-color);
+  color: var(--md-typeset-a-color);
+}
+
+.roomos-tool__subtabs button:focus-visible {
+  outline: 0.15rem solid var(--md-accent-fg-color);
+  outline-offset: -0.15rem;
+}
+
 .roomos-tool__image-preview {
   background: var(--md-code-bg-color);
   border: 1px solid var(--md-default-fg-color--lighter);

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -86,6 +86,25 @@
   background: color-mix(in srgb, #e55353 30%, transparent);
 }
 
+.roomos-tool__file-input {
+  display: block;
+  max-width: 100%;
+}
+
+.roomos-tool__image-preview {
+  background: var(--md-code-bg-color);
+  border: 1px solid var(--md-default-fg-color--lighter);
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+}
+
+.roomos-tool__image-preview img {
+  display: block;
+  margin: 0 auto;
+  max-height: 18rem;
+  max-width: 100%;
+}
+
 .roomos-tool__addition {
   background: color-mix(in srgb, #37a169 35%, transparent);
 }

--- a/docs/Main-Lab/Resources/assets/tools.css
+++ b/docs/Main-Lab/Resources/assets/tools.css
@@ -97,7 +97,7 @@
 .roomos-tool__diff-heading,
 .roomos-tool__diff-row {
   display: grid;
-  grid-template-columns: 3rem 3rem minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(16rem, 1fr));
 }
 
 .roomos-tool__diff-heading {
@@ -107,6 +107,15 @@
   font-weight: 700;
   padding: 0.35rem 0;
   text-transform: uppercase;
+}
+
+.roomos-tool__diff-heading span {
+  padding: 0 0.75rem;
+}
+
+.roomos-tool__diff-heading span + span,
+.roomos-tool__diff-cell + .roomos-tool__diff-cell {
+  border-left: 1px solid var(--md-default-fg-color--lighter);
 }
 
 .roomos-tool__diff-view {
@@ -120,7 +129,13 @@
   font-family: var(--md-code-font-family);
   font-size: 0.75rem;
   line-height: 1.45;
-  min-width: 32rem;
+  min-width: 36rem;
+}
+
+.roomos-tool__diff-cell {
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  min-width: 0;
 }
 
 .roomos-tool__diff-line-number {
@@ -137,11 +152,11 @@
   white-space: pre-wrap;
 }
 
-.roomos-tool__diff-row--delete {
+.roomos-tool__diff-cell--delete {
   background: color-mix(in srgb, #e55353 20%, transparent);
 }
 
-.roomos-tool__diff-row--insert {
+.roomos-tool__diff-cell--insert {
   background: color-mix(in srgb, #37a169 24%, transparent);
 }
 

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -14,6 +14,20 @@
     apos: "'",
   })[entity]);
 
+  const formatXml = (value) => {
+    const document = new DOMParser().parseFromString(value, 'application/xml');
+    const error = document.querySelector('parsererror');
+    if (error) throw new Error('Invalid XML');
+    const compact = new XMLSerializer().serializeToString(document).replace(/>\s*</g, '><');
+    let depth = 0;
+    return compact.replace(/(>)(<)(\/?)/g, '$1\n$2$3').split('\n').map((line) => {
+      if (/^<\//.test(line)) depth -= 1;
+      const formatted = `${'  '.repeat(Math.max(0, depth))}${line}`;
+      if (/^<(?!\/|\?|!)[^>]*[^/]>$/.test(line)) depth += 1;
+      return formatted;
+    }).join('\n');
+  };
+
   const utf8Base64 = (value) => {
     const bytes = new TextEncoder().encode(value);
     let binary = '';
@@ -378,6 +392,30 @@
     });
     configureTextTool(tool.querySelector('[data-roomos-subtool="escape"]'), htmlEscape, 'Enter XML to escape.');
     configureTextTool(tool.querySelector('[data-roomos-subtool="unescape"]'), xmlUnescape, 'Enter escaped XML to unescape.');
+    configureTextTool(tool.querySelector('[data-roomos-subtool="format"]'), formatXml, 'Enter XML to format and validate.');
+  };
+
+  const configureJsonFormatTool = (tool) => {
+    const input = tool.querySelector('textarea:not([readonly])');
+    const output = tool.querySelector('textarea[readonly]');
+    const result = tool.querySelector('[data-roomos-result]');
+    const convert = (indent) => {
+      if (!input.value.trim()) { setStatus(tool, 'Enter JSON to validate.', 'error'); return; }
+      try {
+        output.value = JSON.stringify(JSON.parse(input.value), null, indent);
+        result.hidden = false;
+        setCopyEnabled(tool, true);
+        setStatus(tool, 'JSON is valid.', 'success');
+      } catch (error) {
+        result.hidden = true;
+        setCopyEnabled(tool, false);
+        setStatus(tool, `Invalid JSON: ${error.message}`, 'error');
+      }
+    };
+    tool.querySelector('[data-action="format"]').addEventListener('click', () => convert(2));
+    tool.querySelector('[data-action="minify"]').addEventListener('click', () => convert(0));
+    tool.querySelector('[data-action="copy"]').addEventListener('click', () => copyOutput(tool));
+    tool.querySelector('[data-action="clear"]').addEventListener('click', () => clearTextTool(tool));
   };
 
   const configure = (tool) => {
@@ -405,8 +443,14 @@
       return;
     }
 
+    if (kind === 'json-format') {
+      configureJsonFormatTool(tool);
+      return;
+    }
+
     const transforms = {
       flatten: [(value) => value.replace(/\r?\n/g, ' ').trim(), 'Enter multiline text to flatten.'],
+      'json-string': [JSON.stringify, 'Enter text to escape for JSON.'],
     };
     configureTextTool(tool, ...transforms[kind]);
   };

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -1,0 +1,138 @@
+(() => {
+  const htmlEscape = (value) => value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+
+  const utf8Base64 = (value) => {
+    const bytes = new TextEncoder().encode(value);
+    let binary = '';
+    bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+    return btoa(binary);
+  };
+
+  const setStatus = (tool, message, state = '') => {
+    const status = tool.querySelector('.roomos-tool__status');
+    status.textContent = message;
+    status.dataset.state = state;
+  };
+
+  const setCopyEnabled = (tool, enabled) => {
+    const copyButton = tool.querySelector('[data-action="copy"]');
+    if (copyButton) copyButton.disabled = !enabled;
+  };
+
+  const clearTextTool = (tool) => {
+    tool.querySelectorAll('textarea').forEach((element) => { element.value = ''; });
+    setCopyEnabled(tool, false);
+    setStatus(tool, 'Cleared from this browser tab.', 'success');
+  };
+
+  const copyOutput = async (tool) => {
+    const output = tool.querySelector('textarea[readonly]');
+    if (!output?.value) return;
+
+    try {
+      await navigator.clipboard.writeText(output.value);
+      setStatus(tool, 'Copied to your clipboard.', 'success');
+    } catch {
+      output.focus();
+      output.select();
+      setStatus(tool, 'Select the output and copy it manually.', 'error');
+    }
+  };
+
+  const renderDiff = (tool) => {
+    const leftInput = tool.querySelector('#roomos-diff-left');
+    const rightInput = tool.querySelector('#roomos-diff-right');
+    const ignoreWhitespace = tool.querySelector('#roomos-diff-ignore-whitespace').checked;
+    const normalize = (value) => ignoreWhitespace ? value.replace(/\s/g, '') : value;
+    const left = normalize(leftInput.value);
+    const right = normalize(rightInput.value);
+    const leftOutput = tool.querySelector('[data-output="left"]');
+    const rightOutput = tool.querySelector('[data-output="right"]');
+    const results = tool.querySelector('.roomos-tool__results');
+
+    if (!left && !right) {
+      results.hidden = true;
+      setStatus(tool, 'Paste syntax into at least one field to compare it.', 'error');
+      return;
+    }
+
+    if (left === right) {
+      leftOutput.textContent = left || '(Both snippets are empty.)';
+      rightOutput.textContent = right || '(Both snippets are empty.)';
+      results.hidden = false;
+      setStatus(tool, 'The snippets match.', 'success');
+      return;
+    }
+
+    let prefixLength = 0;
+    while (prefixLength < left.length && left[prefixLength] === right[prefixLength]) prefixLength += 1;
+
+    let leftSuffix = left.length;
+    let rightSuffix = right.length;
+    while (leftSuffix > prefixLength && rightSuffix > prefixLength && left[leftSuffix - 1] === right[rightSuffix - 1]) {
+      leftSuffix -= 1;
+      rightSuffix -= 1;
+    }
+
+    const sharedPrefix = htmlEscape(left.slice(0, prefixLength));
+    const sharedSuffix = htmlEscape(left.slice(leftSuffix));
+    const leftDifference = htmlEscape(left.slice(prefixLength, leftSuffix));
+    const rightDifference = htmlEscape(right.slice(prefixLength, rightSuffix));
+    leftOutput.innerHTML = `${sharedPrefix}<mark class="roomos-tool__difference">${leftDifference || '∅'}</mark>${sharedSuffix}`;
+    rightOutput.innerHTML = `${sharedPrefix}<mark class="roomos-tool__addition">${rightDifference || '∅'}</mark>${sharedSuffix}`;
+    results.hidden = false;
+    setStatus(tool, 'Differences are highlighted. ∅ marks a missing character sequence.', 'success');
+  };
+
+  const configureTextTool = (tool, transform, emptyMessage) => {
+    const input = tool.querySelector('textarea:not([readonly])');
+    const output = tool.querySelector('textarea[readonly]');
+    tool.querySelector('[data-action="convert"]').addEventListener('click', () => {
+      if (!input.value) {
+        output.value = '';
+        setCopyEnabled(tool, false);
+        setStatus(tool, emptyMessage, 'error');
+        return;
+      }
+      output.value = transform(input.value);
+      setCopyEnabled(tool, true);
+      setStatus(tool, 'Converted locally in this browser tab.', 'success');
+    });
+  };
+
+  const configure = (tool) => {
+    if (tool.dataset.initialized === 'true') return;
+    tool.dataset.initialized = 'true';
+    const kind = tool.dataset.roomosTool;
+
+    if (kind === 'diff') {
+      tool.querySelector('[data-action="compare"]').addEventListener('click', () => renderDiff(tool));
+      tool.querySelector('[data-action="clear"]').addEventListener('click', () => {
+        tool.querySelectorAll('textarea').forEach((element) => { element.value = ''; });
+        tool.querySelector('.roomos-tool__results').hidden = true;
+        setStatus(tool, 'Cleared from this browser tab.', 'success');
+      });
+      return;
+    }
+
+    const transforms = {
+      base64: [utf8Base64, 'Enter text to encode.'],
+      flatten: [(value) => value.replace(/\r?\n/g, ' ').trim(), 'Enter multiline text to flatten.'],
+      xml: [htmlEscape, 'Enter XML to escape.'],
+    };
+    configureTextTool(tool, ...transforms[kind]);
+    tool.querySelector('[data-action="copy"]').addEventListener('click', () => copyOutput(tool));
+    tool.querySelector('[data-action="clear"]').addEventListener('click', () => clearTextTool(tool));
+  };
+
+  window.RoomosTools = {
+    init(root = document) {
+      root.querySelectorAll('[data-roomos-tool]').forEach(configure);
+    },
+  };
+})();

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -6,6 +6,14 @@
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
 
+  const xmlUnescape = (value) => value.replace(/&(amp|lt|gt|quot|apos);/g, (_, entity) => ({
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+  })[entity]);
+
   const utf8Base64 = (value) => {
     const bytes = new TextEncoder().encode(value);
     let binary = '';
@@ -43,6 +51,8 @@
 
   const clearTextTool = (tool) => {
     tool.querySelectorAll('textarea').forEach((element) => { element.value = ''; });
+    const result = tool.querySelector('[data-roomos-result]');
+    if (result) result.hidden = true;
     setCopyEnabled(tool, false);
     setStatus(tool, 'Cleared from this browser tab.', 'success');
   };
@@ -244,19 +254,23 @@
   const configureTextTool = (tool, transform, emptyMessage) => {
     const input = tool.querySelector('textarea:not([readonly])');
     const output = tool.querySelector('textarea[readonly]');
+    const result = tool.querySelector('[data-roomos-result]');
     tool.querySelector('[data-action="convert"]').addEventListener('click', () => {
       if (!input.value) {
         output.value = '';
+        if (result) result.hidden = true;
         setCopyEnabled(tool, false);
         setStatus(tool, emptyMessage, 'error');
         return;
       }
       try {
         output.value = transform(input.value);
+        if (result) result.hidden = false;
         setCopyEnabled(tool, true);
         setStatus(tool, 'Converted locally in this browser tab.', 'success');
       } catch {
         output.value = '';
+        if (result) result.hidden = true;
         setCopyEnabled(tool, false);
         setStatus(tool, 'The Base64 value could not be decoded as UTF-8 text.', 'error');
       }
@@ -351,6 +365,21 @@
     });
   };
 
+  const configureXmlTool = (tool) => {
+    const subtools = [...tool.querySelectorAll('[data-roomos-subtool]')];
+    tool.querySelectorAll('[data-xml-tab]').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const selected = tab.dataset.xmlTab;
+        tool.querySelectorAll('[data-xml-tab]').forEach((candidate) => {
+          candidate.setAttribute('aria-selected', candidate === tab ? 'true' : 'false');
+        });
+        subtools.forEach((subtool) => { subtool.hidden = subtool.dataset.roomosSubtool !== selected; });
+      });
+    });
+    configureTextTool(tool.querySelector('[data-roomos-subtool="escape"]'), htmlEscape, 'Enter XML to escape.');
+    configureTextTool(tool.querySelector('[data-roomos-subtool="unescape"]'), xmlUnescape, 'Enter escaped XML to unescape.');
+  };
+
   const configure = (tool) => {
     if (tool.dataset.initialized === 'true') return;
     tool.dataset.initialized = 'true';
@@ -371,9 +400,13 @@
       return;
     }
 
+    if (kind === 'xml') {
+      configureXmlTool(tool);
+      return;
+    }
+
     const transforms = {
       flatten: [(value) => value.replace(/\r?\n/g, ' ').trim(), 'Enter multiline text to flatten.'],
-      xml: [htmlEscape, 'Enter XML to escape.'],
     };
     configureTextTool(tool, ...transforms[kind]);
   };

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -278,6 +278,17 @@
   };
 
   const configureBase64Tool = (tool) => {
+    const subtools = [...tool.querySelectorAll('[data-roomos-subtool]')];
+    tool.querySelectorAll('[data-base64-tab]').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const selected = tab.dataset.base64Tab;
+        tool.querySelectorAll('[data-base64-tab]').forEach((candidate) => {
+          candidate.setAttribute('aria-selected', candidate === tab ? 'true' : 'false');
+        });
+        subtools.forEach((subtool) => { subtool.hidden = subtool.dataset.roomosSubtool !== selected; });
+      });
+    });
+
     const textEncode = tool.querySelector('[data-roomos-subtool="text-encode"]');
     const textDecode = tool.querySelector('[data-roomos-subtool="text-decode"]');
     configureTextTool(textEncode, utf8Base64, 'Enter text to encode.');

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -110,25 +110,30 @@
     return [];
   };
 
-  const renderDiffRow = (view, type, oldNumber, newNumber, text) => {
+  const renderDiffCell = (line) => {
+    const cell = document.createElement('div');
+    cell.className = `roomos-tool__diff-cell${line ? ` roomos-tool__diff-cell--${line.type}` : ''}`;
+    const lineNumber = document.createElement('span');
+    lineNumber.className = 'roomos-tool__diff-line-number';
+    lineNumber.textContent = line?.number ?? '';
+    const content = document.createElement('span');
+    content.className = 'roomos-tool__diff-content';
+    content.textContent = line?.text ?? '';
+    cell.append(lineNumber, content);
+    return cell;
+  };
+
+  const renderDiffRow = (view, oldLine, newLine) => {
     const row = document.createElement('div');
-    row.className = `roomos-tool__diff-row roomos-tool__diff-row--${type}`;
-    if (type === 'skip') {
+    row.className = 'roomos-tool__diff-row';
+    if (oldLine?.type === 'skip') {
+      row.classList.add('roomos-tool__diff-row--skip');
       const summary = document.createElement('span');
       summary.className = 'roomos-tool__diff-content';
-      summary.textContent = text;
+      summary.textContent = oldLine.text;
       row.append(summary);
     } else {
-      [oldNumber, newNumber].forEach((number) => {
-        const lineNumber = document.createElement('span');
-        lineNumber.className = 'roomos-tool__diff-line-number';
-        lineNumber.textContent = number ?? '';
-        row.append(lineNumber);
-      });
-      const content = document.createElement('span');
-      content.className = 'roomos-tool__diff-content';
-      content.textContent = text;
-      row.append(content);
+      row.append(renderDiffCell(oldLine), renderDiffCell(newLine));
     }
     view.append(row);
   };
@@ -158,7 +163,7 @@
     view.replaceChildren();
 
     if (!changedIndexes.length) {
-      renderDiffRow(view, 'equal', '—', '—', 'The snippets match.');
+      renderDiffRow(view, { type: 'equal', number: '—', text: 'The snippets match.' }, { type: 'equal', number: '—', text: 'The snippets match.' });
       results.hidden = false;
       setStatus(tool, 'The snippets match.', 'success');
       return;
@@ -176,23 +181,45 @@
 
     let oldNumber = 1;
     let newNumber = 1;
+    operations.forEach((operation) => {
+      if (operation.type !== 'insert') operation.oldNumber = oldNumber++;
+      if (operation.type !== 'delete') operation.newNumber = newNumber++;
+    });
+
     let hiddenLines = 0;
-    operations.forEach((operation, index) => {
+    for (let index = 0; index < operations.length;) {
+      const operation = operations[index];
       if (!visible.has(index)) {
         hiddenLines += 1;
+        index += 1;
       } else {
         if (hiddenLines) {
-          renderDiffRow(view, 'skip', null, null, `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯`);
+          renderDiffRow(view, { type: 'skip', text: `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯` });
           hiddenLines = 0;
         }
-        if (operation.type === 'equal') renderDiffRow(view, 'equal', oldNumber, newNumber, oldLines[operation.oldIndex]);
-        if (operation.type === 'delete') renderDiffRow(view, 'delete', oldNumber, null, oldLines[operation.oldIndex]);
-        if (operation.type === 'insert') renderDiffRow(view, 'insert', null, newNumber, newLines[operation.newIndex]);
+        if (operation.type === 'equal') {
+          renderDiffRow(view, { type: 'equal', number: operation.oldNumber, text: oldLines[operation.oldIndex] }, { type: 'equal', number: operation.newNumber, text: newLines[operation.newIndex] });
+          index += 1;
+          continue;
+        }
+
+        const changedBlock = [];
+        while (index < operations.length && operations[index].type !== 'equal') changedBlock.push(operations[index++]);
+        const removed = changedBlock.filter((item) => item.type === 'delete');
+        const added = changedBlock.filter((item) => item.type === 'insert');
+        const rows = Math.max(removed.length, added.length);
+        for (let row = 0; row < rows; row += 1) {
+          const removedLine = removed[row];
+          const addedLine = added[row];
+          renderDiffRow(
+            view,
+            removedLine && { type: 'delete', number: removedLine.oldNumber, text: oldLines[removedLine.oldIndex] },
+            addedLine && { type: 'insert', number: addedLine.newNumber, text: newLines[addedLine.newIndex] },
+          );
+        }
       }
-      if (operation.type !== 'insert') oldNumber += 1;
-      if (operation.type !== 'delete') newNumber += 1;
-    });
-    if (hiddenLines) renderDiffRow(view, 'skip', null, null, `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯`);
+    }
+    if (hiddenLines) renderDiffRow(view, { type: 'skip', text: `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯` });
     results.hidden = false;
     setStatus(tool, `${changedIndexes.length} changed line${changedIndexes.length === 1 ? '' : 's'} found.`, 'success');
   };

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -13,6 +13,23 @@
     return btoa(binary);
   };
 
+  const base64Utf8 = (value) => {
+    const normalized = value.replace(/\s/g, '');
+    if (!normalized || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized) || normalized.length % 4 === 1) throw new Error('Invalid Base64');
+    const binary = atob(normalized);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  };
+
+  const imageDataUrlPattern = /^data:image\/(?:avif|bmp|gif|jpe?g|png|svg\+xml|webp);base64,[A-Za-z0-9+/]+={0,2}$/i;
+
+  const readFileAsDataUrl = (file) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(reader.result));
+    reader.addEventListener('error', () => reject(reader.error));
+    reader.readAsDataURL(file);
+  });
+
   const setStatus = (tool, message, state = '') => {
     const status = tool.querySelector('.roomos-tool__status');
     status.textContent = message;
@@ -234,9 +251,92 @@
         setStatus(tool, emptyMessage, 'error');
         return;
       }
-      output.value = transform(input.value);
-      setCopyEnabled(tool, true);
-      setStatus(tool, 'Converted locally in this browser tab.', 'success');
+      try {
+        output.value = transform(input.value);
+        setCopyEnabled(tool, true);
+        setStatus(tool, 'Converted locally in this browser tab.', 'success');
+      } catch {
+        output.value = '';
+        setCopyEnabled(tool, false);
+        setStatus(tool, 'The Base64 value could not be decoded as UTF-8 text.', 'error');
+      }
+    });
+    tool.querySelector('[data-action="copy"]').addEventListener('click', () => copyOutput(tool));
+    tool.querySelector('[data-action="clear"]').addEventListener('click', () => clearTextTool(tool));
+  };
+
+  const configureImagePreview = (tool, dataUrl) => {
+    const preview = tool.querySelector('[data-image-preview]');
+    preview.querySelector('img').src = dataUrl;
+    preview.hidden = false;
+  };
+
+  const clearImagePreview = (tool) => {
+    const preview = tool.querySelector('[data-image-preview]');
+    preview.querySelector('img').removeAttribute('src');
+    preview.hidden = true;
+  };
+
+  const configureBase64Tool = (tool) => {
+    const textEncode = tool.querySelector('[data-roomos-subtool="text-encode"]');
+    const textDecode = tool.querySelector('[data-roomos-subtool="text-decode"]');
+    configureTextTool(textEncode, utf8Base64, 'Enter text to encode.');
+    configureTextTool(textDecode, base64Utf8, 'Enter Base64 text to decode.');
+
+    const imageEncode = tool.querySelector('[data-roomos-subtool="image-encode"]');
+    const imageFile = imageEncode.querySelector('input[type="file"]');
+    const imageOutput = imageEncode.querySelector('textarea[readonly]');
+    imageFile.addEventListener('change', async () => {
+      const [file] = imageFile.files;
+      if (!file) return;
+      try {
+        configureImagePreview(imageEncode, await readFileAsDataUrl(file));
+        setStatus(imageEncode, 'Image selected locally. Encode it to copy a Data URL.', 'success');
+      } catch {
+        clearImagePreview(imageEncode);
+        setStatus(imageEncode, 'The selected image could not be read.', 'error');
+      }
+    });
+    imageEncode.querySelector('[data-action="encode-image"]').addEventListener('click', async () => {
+      const [file] = imageFile.files;
+      if (!file) {
+        setStatus(imageEncode, 'Choose an image file to encode.', 'error');
+        return;
+      }
+      try {
+        imageOutput.value = await readFileAsDataUrl(file);
+        configureImagePreview(imageEncode, imageOutput.value);
+        setCopyEnabled(imageEncode, true);
+        setStatus(imageEncode, 'Image encoded locally as a Data URL.', 'success');
+      } catch {
+        setStatus(imageEncode, 'The selected image could not be encoded.', 'error');
+      }
+    });
+    imageEncode.querySelector('[data-action="copy"]').addEventListener('click', () => copyOutput(imageEncode));
+    imageEncode.querySelector('[data-action="clear"]').addEventListener('click', () => {
+      imageFile.value = '';
+      imageOutput.value = '';
+      clearImagePreview(imageEncode);
+      setCopyEnabled(imageEncode, false);
+      setStatus(imageEncode, 'Cleared from this browser tab.', 'success');
+    });
+
+    const imageDecode = tool.querySelector('[data-roomos-subtool="image-decode"]');
+    const imageInput = imageDecode.querySelector('textarea');
+    imageDecode.querySelector('[data-action="decode-image"]').addEventListener('click', () => {
+      const dataUrl = imageInput.value.trim();
+      if (!imageDataUrlPattern.test(dataUrl)) {
+        clearImagePreview(imageDecode);
+        setStatus(imageDecode, 'Paste a valid image Data URL to decode.', 'error');
+        return;
+      }
+      configureImagePreview(imageDecode, dataUrl);
+      setStatus(imageDecode, 'Image decoded locally in this browser tab.', 'success');
+    });
+    imageDecode.querySelector('[data-action="clear"]').addEventListener('click', () => {
+      imageInput.value = '';
+      clearImagePreview(imageDecode);
+      setStatus(imageDecode, 'Cleared from this browser tab.', 'success');
     });
   };
 
@@ -255,14 +355,16 @@
       return;
     }
 
+    if (kind === 'base64') {
+      configureBase64Tool(tool);
+      return;
+    }
+
     const transforms = {
-      base64: [utf8Base64, 'Enter text to encode.'],
       flatten: [(value) => value.replace(/\r?\n/g, ' ').trim(), 'Enter multiline text to flatten.'],
       xml: [htmlEscape, 'Enter XML to escape.'],
     };
     configureTextTool(tool, ...transforms[kind]);
-    tool.querySelector('[data-action="copy"]').addEventListener('click', () => copyOutput(tool));
-    tool.querySelector('[data-action="clear"]').addEventListener('click', () => clearTextTool(tool));
   };
 
   window.RoomosTools = {

--- a/docs/Main-Lab/Resources/assets/tools.js
+++ b/docs/Main-Lab/Resources/assets/tools.js
@@ -44,49 +44,157 @@
     }
   };
 
+  const splitLines = (value) => value.replace(/\r\n?/g, '\n').split('\n');
+
+  const myersDiff = (oldLines, newLines, equals) => {
+    const max = oldLines.length + newLines.length;
+    const trace = [];
+    const frontier = new Map([[1, 0]]);
+
+    for (let distance = 0; distance <= max; distance += 1) {
+      trace.push(new Map(frontier));
+      for (let diagonal = -distance; diagonal <= distance; diagonal += 2) {
+        const previousDown = frontier.get(diagonal + 1) ?? 0;
+        const previousRight = frontier.get(diagonal - 1) ?? 0;
+        const moveDown = diagonal === -distance || (diagonal !== distance && previousRight < previousDown);
+        let oldIndex = moveDown ? previousDown : previousRight + 1;
+        let newIndex = oldIndex - diagonal;
+
+        while (oldIndex < oldLines.length && newIndex < newLines.length && equals(oldLines[oldIndex], newLines[newIndex])) {
+          oldIndex += 1;
+          newIndex += 1;
+        }
+        frontier.set(diagonal, oldIndex);
+
+        if (oldIndex >= oldLines.length && newIndex >= newLines.length) {
+          const operations = [];
+          let currentOld = oldLines.length;
+          let currentNew = newLines.length;
+
+          for (let step = trace.length - 1; step > 0; step -= 1) {
+            const prior = trace[step];
+            const currentDiagonal = currentOld - currentNew;
+            const priorDiagonal = currentDiagonal === -step || (currentDiagonal !== step && (prior.get(currentDiagonal - 1) ?? 0) < (prior.get(currentDiagonal + 1) ?? 0))
+              ? currentDiagonal + 1
+              : currentDiagonal - 1;
+            const priorOld = prior.get(priorDiagonal) ?? 0;
+            const priorNew = priorOld - priorDiagonal;
+
+            while (currentOld > priorOld && currentNew > priorNew) {
+              operations.push({ type: 'equal', oldIndex: currentOld - 1, newIndex: currentNew - 1 });
+              currentOld -= 1;
+              currentNew -= 1;
+            }
+
+            if (currentOld === priorOld) {
+              operations.push({ type: 'insert', newIndex: currentNew - 1 });
+              currentNew -= 1;
+            } else {
+              operations.push({ type: 'delete', oldIndex: currentOld - 1 });
+              currentOld -= 1;
+            }
+          }
+
+          while (currentOld > 0 && currentNew > 0) {
+            operations.push({ type: 'equal', oldIndex: currentOld - 1, newIndex: currentNew - 1 });
+            currentOld -= 1;
+            currentNew -= 1;
+          }
+          while (currentOld > 0) operations.push({ type: 'delete', oldIndex: --currentOld });
+          while (currentNew > 0) operations.push({ type: 'insert', newIndex: --currentNew });
+          return operations.reverse();
+        }
+      }
+    }
+
+    return [];
+  };
+
+  const renderDiffRow = (view, type, oldNumber, newNumber, text) => {
+    const row = document.createElement('div');
+    row.className = `roomos-tool__diff-row roomos-tool__diff-row--${type}`;
+    if (type === 'skip') {
+      const summary = document.createElement('span');
+      summary.className = 'roomos-tool__diff-content';
+      summary.textContent = text;
+      row.append(summary);
+    } else {
+      [oldNumber, newNumber].forEach((number) => {
+        const lineNumber = document.createElement('span');
+        lineNumber.className = 'roomos-tool__diff-line-number';
+        lineNumber.textContent = number ?? '';
+        row.append(lineNumber);
+      });
+      const content = document.createElement('span');
+      content.className = 'roomos-tool__diff-content';
+      content.textContent = text;
+      row.append(content);
+    }
+    view.append(row);
+  };
+
   const renderDiff = (tool) => {
     const leftInput = tool.querySelector('#roomos-diff-left');
     const rightInput = tool.querySelector('#roomos-diff-right');
     const ignoreWhitespace = tool.querySelector('#roomos-diff-ignore-whitespace').checked;
-    const normalize = (value) => ignoreWhitespace ? value.replace(/\s/g, '') : value;
-    const left = normalize(leftInput.value);
-    const right = normalize(rightInput.value);
-    const leftOutput = tool.querySelector('[data-output="left"]');
-    const rightOutput = tool.querySelector('[data-output="right"]');
+    const showUnchanged = tool.querySelector('#roomos-diff-show-unchanged').checked;
+    const oldLines = splitLines(leftInput.value);
+    const newLines = splitLines(rightInput.value);
     const results = tool.querySelector('.roomos-tool__results');
+    const view = tool.querySelector('.roomos-tool__diff-view');
+    const normalize = (line) => ignoreWhitespace ? line.replace(/\s/g, '') : line;
 
-    if (!left && !right) {
+    if (!leftInput.value && !rightInput.value) {
       results.hidden = true;
       setStatus(tool, 'Paste syntax into at least one field to compare it.', 'error');
       return;
     }
 
-    if (left === right) {
-      leftOutput.textContent = left || '(Both snippets are empty.)';
-      rightOutput.textContent = right || '(Both snippets are empty.)';
+    const operations = myersDiff(oldLines, newLines, (oldLine, newLine) => normalize(oldLine) === normalize(newLine));
+    const changedIndexes = operations.reduce((indexes, operation, index) => {
+      if (operation.type !== 'equal') indexes.push(index);
+      return indexes;
+    }, []);
+    view.replaceChildren();
+
+    if (!changedIndexes.length) {
+      renderDiffRow(view, 'equal', '—', '—', 'The snippets match.');
       results.hidden = false;
       setStatus(tool, 'The snippets match.', 'success');
       return;
     }
 
-    let prefixLength = 0;
-    while (prefixLength < left.length && left[prefixLength] === right[prefixLength]) prefixLength += 1;
-
-    let leftSuffix = left.length;
-    let rightSuffix = right.length;
-    while (leftSuffix > prefixLength && rightSuffix > prefixLength && left[leftSuffix - 1] === right[rightSuffix - 1]) {
-      leftSuffix -= 1;
-      rightSuffix -= 1;
+    const context = 3;
+    const visible = new Set();
+    if (showUnchanged) {
+      operations.forEach((_, index) => visible.add(index));
+    } else {
+      changedIndexes.forEach((index) => {
+        for (let candidate = Math.max(0, index - context); candidate <= Math.min(operations.length - 1, index + context); candidate += 1) visible.add(candidate);
+      });
     }
 
-    const sharedPrefix = htmlEscape(left.slice(0, prefixLength));
-    const sharedSuffix = htmlEscape(left.slice(leftSuffix));
-    const leftDifference = htmlEscape(left.slice(prefixLength, leftSuffix));
-    const rightDifference = htmlEscape(right.slice(prefixLength, rightSuffix));
-    leftOutput.innerHTML = `${sharedPrefix}<mark class="roomos-tool__difference">${leftDifference || '∅'}</mark>${sharedSuffix}`;
-    rightOutput.innerHTML = `${sharedPrefix}<mark class="roomos-tool__addition">${rightDifference || '∅'}</mark>${sharedSuffix}`;
+    let oldNumber = 1;
+    let newNumber = 1;
+    let hiddenLines = 0;
+    operations.forEach((operation, index) => {
+      if (!visible.has(index)) {
+        hiddenLines += 1;
+      } else {
+        if (hiddenLines) {
+          renderDiffRow(view, 'skip', null, null, `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯`);
+          hiddenLines = 0;
+        }
+        if (operation.type === 'equal') renderDiffRow(view, 'equal', oldNumber, newNumber, oldLines[operation.oldIndex]);
+        if (operation.type === 'delete') renderDiffRow(view, 'delete', oldNumber, null, oldLines[operation.oldIndex]);
+        if (operation.type === 'insert') renderDiffRow(view, 'insert', null, newNumber, newLines[operation.newIndex]);
+      }
+      if (operation.type !== 'insert') oldNumber += 1;
+      if (operation.type !== 'delete') newNumber += 1;
+    });
+    if (hiddenLines) renderDiffRow(view, 'skip', null, null, `⋯ ${hiddenLines} unchanged line${hiddenLines === 1 ? '' : 's'} hidden ⋯`);
     results.hidden = false;
-    setStatus(tool, 'Differences are highlighted. ∅ marks a missing character sequence.', 'success');
+    setStatus(tool, `${changedIndexes.length} changed line${changedIndexes.length === 1 ? '' : 's'} found.`, 'success');
   };
 
   const configureTextTool = (tool, transform, emptyMessage) => {

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -151,6 +151,7 @@
       <div class="roomos-tool__subtabs" role="tablist" aria-label="XML tools">
         <button type="button" role="tab" aria-selected="true" aria-controls="roomos-xml-escape" data-xml-tab="escape">Escape XML</button>
         <button type="button" role="tab" aria-selected="false" aria-controls="roomos-xml-unescape" data-xml-tab="unescape">Unescape XML</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="roomos-xml-format" data-xml-tab="format">Format &amp; Validate</button>
       </div>
       <div class="roomos-tool__subtool" id="roomos-xml-escape" role="tabpanel" data-roomos-subtool="escape">
         <div class="roomos-tool__field">
@@ -184,6 +185,44 @@
           <textarea id="roomos-xml-unescape-output" readonly spellcheck="false" placeholder="Unescaped XML appears here"></textarea>
         </div>
       </div>
+      <div class="roomos-tool__subtool" id="roomos-xml-format" role="tabpanel" data-roomos-subtool="format" hidden>
+        <div class="roomos-tool__field">
+          <label for="roomos-xml-format-input">XML to format and validate</label>
+          <textarea id="roomos-xml-format-input" spellcheck="false" placeholder="Paste XML here"></textarea>
+        </div>
+        <div class="roomos-tool__actions">
+          <button class="md-button md-button--primary" type="button" data-action="convert">Format &amp; validate</button>
+          <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+          <button class="md-button" type="button" data-action="clear">Clear</button>
+        </div>
+        <p class="roomos-tool__status" aria-live="polite"></p>
+        <div class="roomos-tool__field" data-roomos-result hidden>
+          <label for="roomos-xml-format-output">Formatted XML</label>
+          <textarea id="roomos-xml-format-output" readonly spellcheck="false"></textarea>
+        </div>
+      </div>
+    </section>
+
+=== "JSON Formatter & Validator"
+
+    Validate local JSON before using it in Cloud xAPI, WebSocket JSON-RPC, macro parameters, or a site manifest.
+
+    <section class="roomos-tool" data-roomos-tool="json-format">
+      <div class="roomos-tool__field"><label for="roomos-json-format-input">JSON</label><textarea id="roomos-json-format-input" spellcheck="false" placeholder="Paste JSON here"></textarea></div>
+      <div class="roomos-tool__actions"><button class="md-button md-button--primary" type="button" data-action="format">Format &amp; validate</button><button class="md-button" type="button" data-action="minify">Minify</button><button class="md-button" type="button" data-action="copy" disabled>Copy</button><button class="md-button" type="button" data-action="clear">Clear</button></div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__field" data-roomos-result hidden><label for="roomos-json-format-output">Validated JSON</label><textarea id="roomos-json-format-output" readonly spellcheck="false"></textarea></div>
+    </section>
+
+=== "JSON String Escaper"
+
+    Convert text or XML into one JSON string literal, including its enclosing quotes. This is useful for a JSON request body that needs multiline content.
+
+    <section class="roomos-tool" data-roomos-tool="json-string">
+      <div class="roomos-tool__field"><label for="roomos-json-string-input">Text to escape</label><textarea id="roomos-json-string-input" spellcheck="false" placeholder="Paste text or XML here"></textarea></div>
+      <div class="roomos-tool__actions"><button class="md-button md-button--primary" type="button" data-action="convert">Escape for JSON</button><button class="md-button" type="button" data-action="copy" disabled>Copy</button><button class="md-button" type="button" data-action="clear">Clear</button></div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__field" data-roomos-result hidden><label for="roomos-json-string-output">JSON string literal</label><textarea id="roomos-json-string-output" readonly spellcheck="false"></textarea></div>
     </section>
 
 <script>

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -9,7 +9,7 @@
 
 === "Code Difference Checker"
 
-    Compare two snippets to find the characters that differ. When **Ignore all whitespace** is enabled, spaces, tabs, and line breaks are removed before comparison.
+    Compare code by line. The compact view shows changed hunks with nearby context; turn on **Show unchanged lines** to inspect the full file. When **Ignore all whitespace** is enabled, whitespace-only changes do not count as differences.
 
     <section class="roomos-tool" data-roomos-tool="diff">
       <div class="roomos-tool__grid roomos-tool__grid--two-up">
@@ -26,20 +26,22 @@
         <input id="roomos-diff-ignore-whitespace" type="checkbox" checked>
         Ignore all whitespace
       </label>
+      <label class="roomos-tool__checkbox" for="roomos-diff-show-unchanged">
+        <input id="roomos-diff-show-unchanged" type="checkbox">
+        Show unchanged lines
+      </label>
       <div class="roomos-tool__actions">
         <button class="md-button md-button--primary" type="button" data-action="compare">Compare</button>
         <button class="md-button" type="button" data-action="clear">Clear</button>
       </div>
       <p class="roomos-tool__status" aria-live="polite"></p>
-      <div class="roomos-tool__results" hidden>
-        <div class="roomos-tool__field">
-          <h3>Your syntax</h3>
-          <pre class="roomos-tool__output" data-output="left"></pre>
+      <div class="roomos-tool__results roomos-tool__diff-results" hidden>
+        <div class="roomos-tool__diff-heading" aria-hidden="true">
+          <span>Old</span>
+          <span>New</span>
+          <span>Difference</span>
         </div>
-        <div class="roomos-tool__field">
-          <h3>Reference syntax</h3>
-          <pre class="roomos-tool__output" data-output="right"></pre>
-        </div>
+        <div class="roomos-tool__diff-view" aria-label="Code comparison result"></div>
       </div>
     </section>
 

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -7,7 +7,7 @@
 
     These tools process text only in the current browser tab. Nothing is sent to a RoomOS device or another service, stored in browser storage, or logged by the Lab Guide. Use **Clear** when you have finished working with credentials or payload fragments.
 
-??? tool "Code Difference Checker"
+=== "Code Difference Checker"
 
     Compare two snippets to find the characters that differ. When **Ignore all whitespace** is enabled, spaces, tabs, and line breaks are removed before comparison.
 
@@ -43,7 +43,7 @@
       </div>
     </section>
 
-??? tool "Base64 Conversion Tool"
+=== "Base64 Conversion Tool"
 
     Convert text to UTF-8 Base64. For a local HTTP Basic authorization value, enter `username:password` and then copy the resulting value after `Basic `.
 
@@ -64,7 +64,7 @@
       </div>
     </section>
 
-??? tool "Flatten Multiline String Tool"
+=== "Flatten Multiline String Tool"
 
     Replace every line break with one space and trim the result. This is useful when a command field requires one line of text.
 
@@ -85,7 +85,7 @@
       </div>
     </section>
 
-??? tool "Escape XML Body"
+=== "Escape XML Body"
 
     Escape XML so that it can safely be used as text inside another XML element, such as the `body` argument of `xCommand UserInterface Extensions Panel Save`.
 

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -9,7 +9,7 @@
 
 === "Code Difference Checker"
 
-    Compare code by line. The compact view shows changed hunks with nearby context; turn on **Show unchanged lines** to inspect the full file. When **Ignore all whitespace** is enabled, whitespace-only changes do not count as differences.
+    Compare code by line. The compact side-by-side view pairs old and new lines in changed hunks with nearby context; turn on **Show unchanged lines** to inspect the full file. When **Ignore all whitespace** is enabled, whitespace-only changes do not count as differences.
 
     <section class="roomos-tool" data-roomos-tool="diff">
       <div class="roomos-tool__grid roomos-tool__grid--two-up">
@@ -37,9 +37,8 @@
       <p class="roomos-tool__status" aria-live="polite"></p>
       <div class="roomos-tool__results roomos-tool__diff-results" hidden>
         <div class="roomos-tool__diff-heading" aria-hidden="true">
-          <span>Old</span>
-          <span>New</span>
-          <span>Difference</span>
+          <span>Old version</span>
+          <span>New version</span>
         </div>
         <div class="roomos-tool__diff-view" aria-label="Code comparison result"></div>
       </div>

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -49,9 +49,14 @@
     Encode and decode UTF-8 text or self-describing image Data URLs. Every operation stays in this browser tab.
 
     <section class="roomos-tool" data-roomos-tool="base64">
-      === "Encode Text"
+      <div class="roomos-tool__subtabs" role="tablist" aria-label="Base64 tools">
+        <button type="button" role="tab" aria-selected="true" aria-controls="roomos-base64-encode-text" data-base64-tab="text-encode">Encode Text</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="roomos-base64-decode-text" data-base64-tab="text-decode">Decode Text</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="roomos-base64-encode-image" data-base64-tab="image-encode">Encode Image</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="roomos-base64-decode-image" data-base64-tab="image-decode">Decode Image</button>
+      </div>
 
-          <div class="roomos-tool__subtool" data-roomos-subtool="text-encode">
+      <div class="roomos-tool__subtool" id="roomos-base64-encode-text" role="tabpanel" data-roomos-subtool="text-encode">
             <div class="roomos-tool__field">
               <label for="roomos-base64-encode-input">Text to encode</label>
               <textarea id="roomos-base64-encode-input" spellcheck="false" placeholder="username:password"></textarea>
@@ -66,11 +71,9 @@
               <label for="roomos-base64-encode-output">Base64 output</label>
               <textarea id="roomos-base64-encode-output" readonly spellcheck="false" placeholder="Encoded output appears here"></textarea>
             </div>
-          </div>
+      </div>
 
-      === "Decode Text"
-
-          <div class="roomos-tool__subtool" data-roomos-subtool="text-decode">
+      <div class="roomos-tool__subtool" id="roomos-base64-decode-text" role="tabpanel" data-roomos-subtool="text-decode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-decode-input">Base64 text</label>
               <textarea id="roomos-base64-decode-input" spellcheck="false" placeholder="Paste Base64 text here"></textarea>
@@ -85,11 +88,9 @@
               <label for="roomos-base64-decode-output">Decoded text</label>
               <textarea id="roomos-base64-decode-output" readonly spellcheck="false" placeholder="Decoded text appears here"></textarea>
             </div>
-          </div>
+      </div>
 
-      === "Encode Image"
-
-          <div class="roomos-tool__subtool" data-roomos-subtool="image-encode">
+      <div class="roomos-tool__subtool" id="roomos-base64-encode-image" role="tabpanel" data-roomos-subtool="image-encode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-image-encode-input">Image file</label>
               <input class="roomos-tool__file-input" id="roomos-base64-image-encode-input" type="file" accept="image/*">
@@ -107,11 +108,9 @@
               <label for="roomos-base64-image-encode-output">Image Data URL</label>
               <textarea id="roomos-base64-image-encode-output" readonly spellcheck="false" placeholder="The encoded image Data URL appears here"></textarea>
             </div>
-          </div>
+      </div>
 
-      === "Decode Image"
-
-          <div class="roomos-tool__subtool" data-roomos-subtool="image-decode">
+      <div class="roomos-tool__subtool" id="roomos-base64-decode-image" role="tabpanel" data-roomos-subtool="image-decode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-image-decode-input">Image Data URL</label>
               <textarea id="roomos-base64-image-decode-input" spellcheck="false" placeholder="Paste a data:image/...;base64,... value here"></textarea>
@@ -124,7 +123,7 @@
             <div class="roomos-tool__image-preview" data-image-preview hidden>
               <img alt="Decoded image preview">
             </div>
-          </div>
+      </div>
     </section>
 
 === "Flatten Multiline String Tool"

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -14,11 +14,11 @@
     <section class="roomos-tool" data-roomos-tool="diff">
       <div class="roomos-tool__grid roomos-tool__grid--two-up">
         <div class="roomos-tool__field">
-          <label for="roomos-diff-left">Your syntax</label>
+          <label for="roomos-diff-left">Script Entry 1</label>
           <textarea id="roomos-diff-left" spellcheck="false" placeholder="Paste your syntax here"></textarea>
         </div>
         <div class="roomos-tool__field">
-          <label for="roomos-diff-right">Reference syntax</label>
+          <label for="roomos-diff-right">Script Entry 2</label>
           <textarea id="roomos-diff-right" spellcheck="false" placeholder="Paste the reference syntax here"></textarea>
         </div>
       </div>
@@ -46,23 +46,85 @@
 
 === "Base64 Conversion Tool"
 
-    Convert text to UTF-8 Base64. For a local HTTP Basic authorization value, enter `username:password` and then copy the resulting value after `Basic `.
+    Encode and decode UTF-8 text or self-describing image Data URLs. Every operation stays in this browser tab.
 
     <section class="roomos-tool" data-roomos-tool="base64">
-      <div class="roomos-tool__field">
-        <label for="roomos-base64-input">Text to encode</label>
-        <textarea id="roomos-base64-input" spellcheck="false" placeholder="username:password"></textarea>
-      </div>
-      <div class="roomos-tool__actions">
-        <button class="md-button md-button--primary" type="button" data-action="convert">Encode</button>
-        <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
-        <button class="md-button" type="button" data-action="clear">Clear</button>
-      </div>
-      <p class="roomos-tool__status" aria-live="polite"></p>
-      <div class="roomos-tool__field">
-        <label for="roomos-base64-output">Base64 output</label>
-        <textarea id="roomos-base64-output" readonly spellcheck="false" placeholder="Encoded output appears here"></textarea>
-      </div>
+      === "Encode Text"
+
+          <div class="roomos-tool__subtool" data-roomos-subtool="text-encode">
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-encode-input">Text to encode</label>
+              <textarea id="roomos-base64-encode-input" spellcheck="false" placeholder="username:password"></textarea>
+            </div>
+            <div class="roomos-tool__actions">
+              <button class="md-button md-button--primary" type="button" data-action="convert">Encode text</button>
+              <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+              <button class="md-button" type="button" data-action="clear">Clear</button>
+            </div>
+            <p class="roomos-tool__status" aria-live="polite"></p>
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-encode-output">Base64 output</label>
+              <textarea id="roomos-base64-encode-output" readonly spellcheck="false" placeholder="Encoded output appears here"></textarea>
+            </div>
+          </div>
+
+      === "Decode Text"
+
+          <div class="roomos-tool__subtool" data-roomos-subtool="text-decode">
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-decode-input">Base64 text</label>
+              <textarea id="roomos-base64-decode-input" spellcheck="false" placeholder="Paste Base64 text here"></textarea>
+            </div>
+            <div class="roomos-tool__actions">
+              <button class="md-button md-button--primary" type="button" data-action="convert">Decode text</button>
+              <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+              <button class="md-button" type="button" data-action="clear">Clear</button>
+            </div>
+            <p class="roomos-tool__status" aria-live="polite"></p>
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-decode-output">Decoded text</label>
+              <textarea id="roomos-base64-decode-output" readonly spellcheck="false" placeholder="Decoded text appears here"></textarea>
+            </div>
+          </div>
+
+      === "Encode Image"
+
+          <div class="roomos-tool__subtool" data-roomos-subtool="image-encode">
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-image-encode-input">Image file</label>
+              <input class="roomos-tool__file-input" id="roomos-base64-image-encode-input" type="file" accept="image/*">
+            </div>
+            <div class="roomos-tool__image-preview" data-image-preview hidden>
+              <img alt="Selected image preview">
+            </div>
+            <div class="roomos-tool__actions">
+              <button class="md-button md-button--primary" type="button" data-action="encode-image">Encode image</button>
+              <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+              <button class="md-button" type="button" data-action="clear">Clear</button>
+            </div>
+            <p class="roomos-tool__status" aria-live="polite"></p>
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-image-encode-output">Image Data URL</label>
+              <textarea id="roomos-base64-image-encode-output" readonly spellcheck="false" placeholder="The encoded image Data URL appears here"></textarea>
+            </div>
+          </div>
+
+      === "Decode Image"
+
+          <div class="roomos-tool__subtool" data-roomos-subtool="image-decode">
+            <div class="roomos-tool__field">
+              <label for="roomos-base64-image-decode-input">Image Data URL</label>
+              <textarea id="roomos-base64-image-decode-input" spellcheck="false" placeholder="Paste a data:image/...;base64,... value here"></textarea>
+            </div>
+            <div class="roomos-tool__actions">
+              <button class="md-button md-button--primary" type="button" data-action="decode-image">Decode image</button>
+              <button class="md-button" type="button" data-action="clear">Clear</button>
+            </div>
+            <p class="roomos-tool__status" aria-live="polite"></p>
+            <div class="roomos-tool__image-preview" data-image-preview hidden>
+              <img alt="Decoded image preview">
+            </div>
+          </div>
     </section>
 
 === "Flatten Multiline String Tool"

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -1,129 +1,132 @@
 {{ config.cProps.devNotice }}
 {{ config.cProps.acronyms }}
 
+<link rel="stylesheet" href="../assets/tools.css">
+
+!!! info "Private, local processing"
+
+    These tools process text only in the current browser tab. Nothing is sent to a RoomOS device or another service, stored in browser storage, or logged by the Lab Guide. Use **Clear** when you have finished working with credentials or payload fragments.
+
 ??? tool "Code Difference Checker"
-    <p>Use this tool to compare your syntax against the answers to help find stray characters, artifacts or to compare your successful implementation against the lab guides to understand the differences</p>
-    <div>
-        <div style="display: flex; justify-content: space-between;">
-            <textarea id="codeDif-text1" placeholder="Enter first code snippet here..." style="width: 45%; height: 300px; margin: 0 2%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; font-family: monospace;"></textarea>
-            <textarea id="codeDif-text2" placeholder="Enter second code snippet here..." style="width: 45%; height: 300px; margin: 0 2%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; font-family: monospace;"></textarea>
+
+    Compare two snippets to find the characters that differ. When **Ignore all whitespace** is enabled, spaces, tabs, and line breaks are removed before comparison.
+
+    <section class="roomos-tool" data-roomos-tool="diff">
+      <div class="roomos-tool__grid roomos-tool__grid--two-up">
+        <div class="roomos-tool__field">
+          <label for="roomos-diff-left">Your syntax</label>
+          <textarea id="roomos-diff-left" spellcheck="false" placeholder="Paste your syntax here"></textarea>
         </div>
-        <br><br>
-        <label style="font-family: Arial, sans-serif;">
-            <input type="checkbox" id="codeDif-ignoreWhitespace" checked>
-            Ignore Whitespace
-        </label>
-        <button id="codeDif-checkButton" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; background-color: rgba(192, 192, 192, 0.1); cursor: pointer; margin: 20px 0; font-size: 16px;">Check Differences</button>
-        <h2 style="font-family: Arial, sans-serif;">Differences:</h2>
-        <div style="display: flex; justify-content: space-between;">
-            <div id="codeDif-result1" style="width: 45%; color: #000000; background: #f9f9f9; border: 1px solid #ccc; padding: 10px; font-family: monospace; border-radius: 4px; white-space: pre-wrap;"></div>
-            <div id="codeDif-result2" style="width: 45%; color: #000000; background: #f9f9f9; border: 1px solid #ccc; padding: 10px; font-family: monospace; border-radius: 4px; white-space: pre-wrap;"></div>
+        <div class="roomos-tool__field">
+          <label for="roomos-diff-right">Reference syntax</label>
+          <textarea id="roomos-diff-right" spellcheck="false" placeholder="Paste the reference syntax here"></textarea>
         </div>
-        <script>
-            document.addEventListener('DOMContentLoaded', function() {
-                function escapeHTML(html) {
-                    var text = document.createTextNode(html);
-                    var div = document.createElement('div');
-                    div.appendChild(text);
-                    return div.innerHTML;
-                }
-                function checkDifferences() {
-                    var ignoreWhitespace = document.getElementById('codeDif-ignoreWhitespace').checked;
-                    var code1 = document.getElementById('codeDif-text1').value.split('\n').map(function(line) {
-                        return ignoreWhitespace ? line.trim() : line;
-                    });
-                    var code2 = document.getElementById('codeDif-text2').value.split('\n').map(function(line) {
-                        return ignoreWhitespace ? line.trim() : line;
-                    });
-                    var output1 = '';
-                    var output2 = '';
-                    // Use forEach to iterate over lines
-                    code1.forEach(function(line1, index) {
-                        var line2 = code2[index] || '';
-                        var maxLength = Math.max(line1.length, line2.length);
-                        // Create an array of characters for each line
-                        var chars1 = line1.split('');
-                        var chars2 = line2.split('');
-                        // Use forEach to compare characters
-                        chars1.forEach(function(char1, i) {
-                            var char2 = chars2[i] || '';
-                            if (char1 === char2) {
-                                output1 += escapeHTML(char1);
-                                output2 += escapeHTML(char2);
-                            } else {
-                                if (char1) output1 += '<span style="background-color: #ffcdd2;">' + escapeHTML(char1) + '</span>';
-                                if (char2) output2 += '<span style="background-color: #c8e6c9;">' + escapeHTML(char2) + '</span>';
-                            }
-                        });
-                        output1 += '\n'; // Add a newline after each line
-                        output2 += '\n';
-                    });
-                    document.getElementById('codeDif-result1').innerHTML = output1;
-                    document.getElementById('codeDif-result2').innerHTML = output2;
-                }
-                document.getElementById('codeDif-checkButton').addEventListener('click', checkDifferences);
-            });
-        </script>
-    </div>
+      </div>
+      <label class="roomos-tool__checkbox" for="roomos-diff-ignore-whitespace">
+        <input id="roomos-diff-ignore-whitespace" type="checkbox" checked>
+        Ignore all whitespace
+      </label>
+      <div class="roomos-tool__actions">
+        <button class="md-button md-button--primary" type="button" data-action="compare">Compare</button>
+        <button class="md-button" type="button" data-action="clear">Clear</button>
+      </div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__results" hidden>
+        <div class="roomos-tool__field">
+          <h3>Your syntax</h3>
+          <pre class="roomos-tool__output" data-output="left"></pre>
+        </div>
+        <div class="roomos-tool__field">
+          <h3>Reference syntax</h3>
+          <pre class="roomos-tool__output" data-output="right"></pre>
+        </div>
+      </div>
+    </section>
 
 ??? tool "Base64 Conversion Tool"
-    <p>Convert any string into a base64 encoded string</p>
-    <p>If setting up Basic Auth for an endpoint, be sure to use a colon <strong>:</strong> to separate the Username and Password</p>
-    <p>Example: username:password <p>
-    <div>
-        <input type="text" id="base64TextInput" placeholder="Convert to Base64" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; box-sizing: border-box; width: 100%; margin-right: 5px;">
-        <button id="base64ConvertButton" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; background-color: rgba(192, 192, 192, 0.1); cursor: pointer;">Click to Convert</button>
-        <br><br>
-        Copy your converted Base64 String
-        <div id="base64Output" style="border: 2px solid #C0C0C0; border-radius: 5px; min-height: 45px; padding: 10px; box-sizing: border-box; display: flex; justify-content: space-between; align-items: center;">
-            <span id="outputText"></span>
-        </div>
-        <script>
-            document.getElementById('base64ConvertButton').onclick = function() {
-                const inputText = document.getElementById('base64TextInput').value;
-                const base64Text = btoa(inputText);
-                document.getElementById('outputText').textContent = base64Text; // Update only the text span
-            };
-        </script>
-    </div>
 
+    Convert text to UTF-8 Base64. For a local HTTP Basic authorization value, enter `username:password` and then copy the resulting value after `Basic `.
+
+    <section class="roomos-tool" data-roomos-tool="base64">
+      <div class="roomos-tool__field">
+        <label for="roomos-base64-input">Text to encode</label>
+        <textarea id="roomos-base64-input" spellcheck="false" placeholder="username:password"></textarea>
+      </div>
+      <div class="roomos-tool__actions">
+        <button class="md-button md-button--primary" type="button" data-action="convert">Encode</button>
+        <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+        <button class="md-button" type="button" data-action="clear">Clear</button>
+      </div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__field">
+        <label for="roomos-base64-output">Base64 output</label>
+        <textarea id="roomos-base64-output" readonly spellcheck="false" placeholder="Encoded output appears here"></textarea>
+      </div>
+    </section>
 
 ??? tool "Flatten Multiline String Tool"
-    <p>Some command fields can't accept a multi-line string. Use this tool to remove line breaks in your string.</p>
-    <div>
-        <textarea id="textInput" placeholder="Enter your text here" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; box-sizing: border-box; width: 100%; height: 100px; margin-right: 5px;"></textarea>
-        <br><br>
-        <button id="flattenButton" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; background-color: rgba(192, 192, 192, 0.1); cursor: pointer;">Flatten Text</button>
-        <br><br>
-        Copy your flattened text
-        <div id="flattenOutputContainer" style="border: 2px solid #C0C0C0; border-radius: 5px; min-height: 45px; padding: 10px; box-sizing: border-box; display: flex; justify-content: space-between; align-items: center;">
-            <span id="flattenOutputText"></span>
-        </div>
-        <script>
-            document.getElementById('flattenButton').onclick = function() {
-                const inputText = document.getElementById('textInput').value;
-                const flattenedText = inputText.replace(/\n/g, ' ').trim(); // Replace new lines with spaces and trim
-                document.getElementById('flattenOutputText').textContent = flattenedText; // Update only the text span
-            };
-        </script>
-    </div>
 
-??? tool "Stringify XML Body"
-    <p>Use this tool to "Stringify" your XML string. Some data fields may be formatted in XML itself, so if your string is written in XML, then you may confuse that xAPI call if you don't handle the syntax appropriately.</p>
-    <div>
-        <textarea id="xmlInput" placeholder="Enter your XML here" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; box-sizing: border-box; width: 100%; height: 100px; margin-right: 5px;"></textarea>
-        <br><br>
-        <button id="stringifyXmlButton" style="border: 2px solid #C0C0C0; border-radius: 5px; padding: 10px; background-color: rgba(192, 192, 192, 0.1); cursor: pointer;">Stringify XML</button>
-        <br><br>
-        Copy your stringified XML
-        <div id="xmlOutputContainer" style="border: 2px solid #C0C0C0; border-radius: 5px; min-height: 45px; padding: 10px; box-sizing: border-box; display: flex; justify-content: space-between; align-items: center;">
-            <span id="xmlOutputText"></span>
-        </div>
-        <script>
-            document.getElementById('stringifyXmlButton').onclick = function() {
-                const inputText = document.getElementById('xmlInput').value;
-                const stringifiedXml = inputText.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/'/g, '&apos;').replace(/"/g, '&quot;').trim();
-                document.getElementById('xmlOutputText').textContent = stringifiedXml; // Update only the text span
-            };
-        </script>
-    </div>
+    Replace every line break with one space and trim the result. This is useful when a command field requires one line of text.
+
+    <section class="roomos-tool" data-roomos-tool="flatten">
+      <div class="roomos-tool__field">
+        <label for="roomos-flatten-input">Multiline text</label>
+        <textarea id="roomos-flatten-input" spellcheck="false" placeholder="Paste multiline text here"></textarea>
+      </div>
+      <div class="roomos-tool__actions">
+        <button class="md-button md-button--primary" type="button" data-action="convert">Flatten</button>
+        <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+        <button class="md-button" type="button" data-action="clear">Clear</button>
+      </div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__field">
+        <label for="roomos-flatten-output">Flattened text</label>
+        <textarea id="roomos-flatten-output" readonly spellcheck="false" placeholder="Flattened text appears here"></textarea>
+      </div>
+    </section>
+
+??? tool "Escape XML Body"
+
+    Escape XML so that it can safely be used as text inside another XML element, such as the `body` argument of `xCommand UserInterface Extensions Panel Save`.
+
+    <section class="roomos-tool" data-roomos-tool="xml">
+      <div class="roomos-tool__field">
+        <label for="roomos-xml-input">XML to escape</label>
+        <textarea id="roomos-xml-input" spellcheck="false" placeholder="Paste XML here"></textarea>
+      </div>
+      <div class="roomos-tool__actions">
+        <button class="md-button md-button--primary" type="button" data-action="convert">Escape XML</button>
+        <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+        <button class="md-button" type="button" data-action="clear">Clear</button>
+      </div>
+      <p class="roomos-tool__status" aria-live="polite"></p>
+      <div class="roomos-tool__field">
+        <label for="roomos-xml-output">Escaped XML</label>
+        <textarea id="roomos-xml-output" readonly spellcheck="false" placeholder="Escaped XML appears here"></textarea>
+      </div>
+    </section>
+
+<script>
+  window.RoomosToolsLoader ??= (() => {
+    let ready;
+
+    return () => {
+      if (window.RoomosTools) {
+        window.RoomosTools.init(document);
+        return;
+      }
+
+      ready ??= new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = '../assets/tools.js';
+        script.addEventListener('load', resolve, { once: true });
+        script.addEventListener('error', reject, { once: true });
+        document.head.append(script);
+      });
+      ready.then(() => window.RoomosTools.init(document));
+    };
+  })();
+
+  if (typeof document$ !== 'undefined') document$.subscribe(window.RoomosToolsLoader);
+  else window.RoomosToolsLoader();
+</script>

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -44,7 +44,7 @@
       </div>
     </section>
 
-=== "Base64 Conversion Tool"
+=== "Base64 Conversion Tools"
 
     Encode and decode UTF-8 text or self-describing image Data URLs. Every operation stays in this browser tab.
 
@@ -55,7 +55,6 @@
         <button type="button" role="tab" aria-selected="false" aria-controls="roomos-base64-encode-image" data-base64-tab="image-encode">Encode Image</button>
         <button type="button" role="tab" aria-selected="false" aria-controls="roomos-base64-decode-image" data-base64-tab="image-decode">Decode Image</button>
       </div>
-
       <div class="roomos-tool__subtool" id="roomos-base64-encode-text" role="tabpanel" data-roomos-subtool="text-encode">
             <div class="roomos-tool__field">
               <label for="roomos-base64-encode-input">Text to encode</label>
@@ -72,7 +71,6 @@
               <textarea id="roomos-base64-encode-output" readonly spellcheck="false" placeholder="Encoded output appears here"></textarea>
             </div>
       </div>
-
       <div class="roomos-tool__subtool" id="roomos-base64-decode-text" role="tabpanel" data-roomos-subtool="text-decode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-decode-input">Base64 text</label>
@@ -89,7 +87,6 @@
               <textarea id="roomos-base64-decode-output" readonly spellcheck="false" placeholder="Decoded text appears here"></textarea>
             </div>
       </div>
-
       <div class="roomos-tool__subtool" id="roomos-base64-encode-image" role="tabpanel" data-roomos-subtool="image-encode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-image-encode-input">Image file</label>
@@ -109,7 +106,6 @@
               <textarea id="roomos-base64-image-encode-output" readonly spellcheck="false" placeholder="The encoded image Data URL appears here"></textarea>
             </div>
       </div>
-
       <div class="roomos-tool__subtool" id="roomos-base64-decode-image" role="tabpanel" data-roomos-subtool="image-decode" hidden>
             <div class="roomos-tool__field">
               <label for="roomos-base64-image-decode-input">Image Data URL</label>

--- a/docs/Main-Lab/Resources/res_tools.md
+++ b/docs/Main-Lab/Resources/res_tools.md
@@ -122,9 +122,9 @@
       </div>
     </section>
 
-=== "Flatten Multiline String Tool"
+=== "Flatten Multiline Text"
 
-    Replace every line break with one space and trim the result. This is useful when a command field requires one line of text.
+    Replace each line break with one space and trim the result. Existing spaces are preserved; this tool does not normalize or collapse them.
 
     <section class="roomos-tool" data-roomos-tool="flatten">
       <div class="roomos-tool__field">
@@ -137,7 +137,7 @@
         <button class="md-button" type="button" data-action="clear">Clear</button>
       </div>
       <p class="roomos-tool__status" aria-live="polite"></p>
-      <div class="roomos-tool__field">
+      <div class="roomos-tool__field" data-roomos-result hidden>
         <label for="roomos-flatten-output">Flattened text</label>
         <textarea id="roomos-flatten-output" readonly spellcheck="false" placeholder="Flattened text appears here"></textarea>
       </div>
@@ -145,22 +145,44 @@
 
 === "Escape XML Body"
 
-    Escape XML so that it can safely be used as text inside another XML element, such as the `body` argument of `xCommand UserInterface Extensions Panel Save`.
+    Escape XML so it can be used as text inside another XML element, such as the `body` argument of `xCommand UserInterface Extensions Panel Save`. Use **Unescape XML** to inspect or revise an existing escaped payload.
 
     <section class="roomos-tool" data-roomos-tool="xml">
-      <div class="roomos-tool__field">
-        <label for="roomos-xml-input">XML to escape</label>
-        <textarea id="roomos-xml-input" spellcheck="false" placeholder="Paste XML here"></textarea>
+      <div class="roomos-tool__subtabs" role="tablist" aria-label="XML tools">
+        <button type="button" role="tab" aria-selected="true" aria-controls="roomos-xml-escape" data-xml-tab="escape">Escape XML</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="roomos-xml-unescape" data-xml-tab="unescape">Unescape XML</button>
       </div>
-      <div class="roomos-tool__actions">
-        <button class="md-button md-button--primary" type="button" data-action="convert">Escape XML</button>
-        <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
-        <button class="md-button" type="button" data-action="clear">Clear</button>
+      <div class="roomos-tool__subtool" id="roomos-xml-escape" role="tabpanel" data-roomos-subtool="escape">
+        <div class="roomos-tool__field">
+          <label for="roomos-xml-escape-input">XML to escape</label>
+          <textarea id="roomos-xml-escape-input" spellcheck="false" placeholder="Paste XML here"></textarea>
+        </div>
+        <div class="roomos-tool__actions">
+          <button class="md-button md-button--primary" type="button" data-action="convert">Escape XML</button>
+          <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+          <button class="md-button" type="button" data-action="clear">Clear</button>
+        </div>
+        <p class="roomos-tool__status" aria-live="polite"></p>
+        <div class="roomos-tool__field" data-roomos-result hidden>
+          <label for="roomos-xml-escape-output">Escaped XML</label>
+          <textarea id="roomos-xml-escape-output" readonly spellcheck="false" placeholder="Escaped XML appears here"></textarea>
+        </div>
       </div>
-      <p class="roomos-tool__status" aria-live="polite"></p>
-      <div class="roomos-tool__field">
-        <label for="roomos-xml-output">Escaped XML</label>
-        <textarea id="roomos-xml-output" readonly spellcheck="false" placeholder="Escaped XML appears here"></textarea>
+      <div class="roomos-tool__subtool" id="roomos-xml-unescape" role="tabpanel" data-roomos-subtool="unescape" hidden>
+        <div class="roomos-tool__field">
+          <label for="roomos-xml-unescape-input">Escaped XML</label>
+          <textarea id="roomos-xml-unescape-input" spellcheck="false" placeholder="Paste escaped XML here"></textarea>
+        </div>
+        <div class="roomos-tool__actions">
+          <button class="md-button md-button--primary" type="button" data-action="convert">Unescape XML</button>
+          <button class="md-button" type="button" data-action="copy" disabled>Copy</button>
+          <button class="md-button" type="button" data-action="clear">Clear</button>
+        </div>
+        <p class="roomos-tool__status" aria-live="polite"></p>
+        <div class="roomos-tool__field" data-roomos-result hidden>
+          <label for="roomos-xml-unescape-output">XML</label>
+          <textarea id="roomos-xml-unescape-output" readonly spellcheck="false" placeholder="Unescaped XML appears here"></textarea>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

- refresh the local-only Tools page with a side-by-side line comparison
- add local text and image Base64 tools, XML escape/unescape/formatting, and JSON helpers
- keep all tool processing in the learner’s current browser tab

## Verification

- exercised the comparison view with the supplied JoinZoom scripts
- verified Base64 text/image flows, XML round-trips/formatting, and JSON validation/string escaping in the isolated local preview